### PR TITLE
Remove the resolver for attributesInstances, which caused a graphql error

### DIFF
--- a/etc/di.xml
+++ b/etc/di.xml
@@ -39,9 +39,6 @@
                 <item name="comments" xsi:type="object">
                     Mageplaza\BlogGraphQl\Model\Resolver\FilterArgument
                 </item>
-                <item name="products" xsi:type="object">
-                    Mageplaza\BlogGraphQl\Model\Resolver\FilterArgument
-                </item>
             </argument>
         </arguments>
     </type>


### PR DESCRIPTION
See https://github.com/mageplaza/magento-2-blog-graphql/issues/2 for full details on this issue.

- In etc/di.xml there was an override for the `products` attribute instance
- This caused an error when filtering products via the standard Magento `products` query
- Fixes https://github.com/mageplaza/magento-2-blog-graphql/issues/2

Removing these lines results in the `products` attribute instance falling back to the `Magento\CatalogGraphQl\Model\Resolver\Products\FilterArgument\ProductEntityAttributesForAst` resolver, which fixes the issue.